### PR TITLE
fix: work with new-SES -based Zoe and spawner

### DIFF
--- a/api/deploy.js
+++ b/api/deploy.js
@@ -178,8 +178,8 @@ export default async function deployApi(referencesPromise, { bundleSource, pathR
   console.log(`-- Contract Name: ${dappConstants.CONTRACT_NAME}`);
   console.log(`-- InstanceHandle Register Key: ${INSTANCE_REG_KEY}`);
 
-  const { source, moduleFormat } = await bundleSource(pathResolve('./src/handler.js'));
-  const handlerInstall = E(spawner).install(source, moduleFormat);
+  const bundle = await bundleSource(pathResolve('./src/handler.js'));
+  const handlerInstall = E(spawner).install(bundle);
 
   const brandPs = [];
   const keywords = [];

--- a/contract/deploy.js
+++ b/contract/deploy.js
@@ -48,10 +48,8 @@ export default async function deployContract(
   // and install it on Zoe. This returns an installationHandle, an
   // opaque, unforgeable identifier for our contract code that we can
   // reuse again and again to create new, live contract instances.
-  const { source, moduleFormat } = await bundleSource(
-    pathResolve(`./src/contract.js`),
-  );
-  const installationHandle = await E(zoe).install(source, moduleFormat);
+  const bundle = await bundleSource(pathResolve(`./src/contract.js`));
+  const installationHandle = await E(zoe).install(bundle);
 
   // Let's share this installationHandle with other people, so that
   // they can run our encouragement contract code by making a contract


### PR DESCRIPTION
The Zoe API has changed: `zoe~.install(bundle)` instead of
`zoe~.install(source, moduleFormat)`, and `zoe.getInstallation` returns the
bundle object instead of a single string (so you must use a deep-equality
predicate).

This should not land until after https://github.com/Agoric/agoric-sdk/pull/1201 lands, but it does not need to land right away, because Zoe's API retains backwards compatibility for now.
