### PR TITLE
chore: turn off test, since no ui tests

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -10,7 +10,7 @@
     "lint-check": "exit 0",
     "lint-fix": "exit 0",
     "start": "react-scripts start",
-    "test": "react-scripts test --env=jsdom",
+    "test": "exit 0",
     "build": "exit 0",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
React-scripts returns an exit 1 if there are no tests :/ This turns off the tests, since currently we do not have any.

Fixes the following in agoric-sdk CI:

> @agoric/dapp-simple-exchange-ui
$ react-scripts test --env=jsdom
No tests found, exiting with code 1
Run with `--passWithNoTests` to exit with code 0
In /home/runner/work/agoric-sdk/agoric-sdk/dapp/ui
  18 files checked.
  testMatch: /home/runner/work/agoric-sdk/agoric-sdk/dapp/ui/src/**/__tests__/**/*.{js,jsx,ts,tsx}, /home/runner/work/agoric-sdk/agoric-sdk/dapp/ui/src/**/*.{spec,test}.{js,jsx,ts,tsx} - 0 matches
  testPathIgnorePatterns: /node_modules/ - 18 matches
  testRegex:  - 0 matches
Pattern:  - 0 matches
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed.
Exit code: 1
Command: /opt/hostedtoolcache/node/14.16.1/x64/bin/node
Arguments: /home/runner/work/agoric-sdk/agoric-sdk/dapp/.yarn/releases/yarn-1.22.4.js run test
Directory: /home/runner/work/agoric-sdk/agoric-sdk/dapp/ui
Output: